### PR TITLE
Fix encoding error on some systems (Python 2.6)

### DIFF
--- a/qrcode/main.py
+++ b/qrcode/main.py
@@ -232,7 +232,7 @@ class QRCode:
                 out.write('\x1b[38;5;255m')   # Foreground white
             for c in range(-self.border, modcount+self.border):
                 pos = get_module(r, c) + (get_module(r+1, c) << 1)
-                out.write(codes[pos])
+                out.write(codes[pos].encode('utf-8'))
             if tty:
                 out.write('\x1b[0m')
             out.write('\n')


### PR DESCRIPTION
Fixes the following error:
Traceback (most recent call last):
  File "/usr/local/bin/qr", line 9, in <module>
    load_entry_point('qrcode==5.1', 'console_scripts', 'qr')()
  File "/usr/local/lib/python2.6/dist-packages/qrcode/console_scripts.py", line 59, in main
    qr.print_ascii(tty=True)
  File "/usr/local/lib/python2.6/dist-packages/qrcode/main.py", line 235, in print_ascii
    out.write(codes[pos])
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2588' in position 0: ordinal not in range(128)
